### PR TITLE
Fixed tag-specified rich synopsis not working & added logical improvements

### DIFF
--- a/js/src/forum/addSummaryExcerpt.tsx
+++ b/js/src/forum/addSummaryExcerpt.tsx
@@ -30,17 +30,36 @@ export default function addSummaryExcerpt() {
 
     const tags = discussion.tags();
     let tag;
+    let disableSyno = false;
+    let disableRich = false;
     if (tags) {
-      tag = tags[tags.length - 1];
+      for (const tagTemp of tags) {
+        if (tagTemp?.excerptLength() === 0) {
+          // Disable syno if any included tag disallows syno
+          disableSyno = true;
+        }
+        if (!tagTemp?.richExcerpts() && (tagTemp.isPrimary() || tagTemp.parent())) {
+          // Disable rich only if a unique tag disallows rich
+          disableRich = true;
+        }
+        if (tagTemp?.isPrimary()) {
+          // If this is a primary tag, then it's good for following procedure
+          tag = tagTemp;
+        }
+      }
+      if (!tag) {
+        // Failsafe
+        tag = tags[tags.length - 1];
+      }
     }
 
     const excerptPost = app.forum.attribute<string>('synopsis.excerpt_type') === 'first' ? discussion.firstPost() : discussion.lastPost();
     const excerptLength = typeof tag?.excerptLength() === 'number' ? tag?.excerptLength() : app.forum.attribute<number>('synopsis.excerpt_length');
-    const richExcerpt = typeof tag?.richExcerpts() === 'number' ? tag?.richExcerpts() : app.forum.attribute<boolean>('synopsis.rich_excerpts');
+    const richExcerpt = !disableRich || app.forum.attribute<boolean>('synopsis.rich_excerpts');
     const onMobile = app.session.user ? app.session.user.preferences()?.showSynopsisExcerptsOnMobile : false;
 
     // A length of zero means we don't want a synopsis for this discussion, so do nothing.
-    if (excerptLength === 0) {
+    if (excerptLength === 0 || disableSyno) {
       return;
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Fixed tag-specified rich synopsis not working. The original code tried to determine if `tag?.richExcerpts()` is a number which is obviously wrong.
I also added some improvements to multi-tag handling logics according to my own understanding, and I've briefly explained which in the comments.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
